### PR TITLE
Exercise 4: fix example

### DIFF
--- a/exercise4/README.md
+++ b/exercise4/README.md
@@ -37,8 +37,7 @@ query SocialClubWithAtLeast5Members {
 
 mutation CreateProduct {
   createOrUpdateProduct(
-    pk: 1
-    inp: {name: "Product 1", socialClubId: 5, price: 50, quality: GOOD}
+    inp: {pk: 1, name: "Product 1", socialClubId: 5, price: 50, quality: GOOD}
   ) {
     id
     name


### PR DESCRIPTION
Put `pk` into the product input type. This prevents the following error message: 

> "Unknown argument 'pk' on field 'Mutation.createOrUpdateProduct'.",